### PR TITLE
TPMHandleSigner / RSA-PSS support in signers / thread-safe signers

### DIFF
--- a/der.go
+++ b/der.go
@@ -242,7 +242,7 @@ func Parse(b []byte) (*TPMKey, error) {
 	}
 
 	//   parent      INTEGER,
-	var parent int
+	var parent uint32
 	if !s.ReadASN1Integer(&parent) {
 		return nil, errors.New("failed reading parent")
 	}

--- a/signer.go
+++ b/signer.go
@@ -82,3 +82,77 @@ func NewTPMKeySigner(k *TPMKey, ownerAuth func() ([]byte, error), tpm func() tra
 		auth:      auth,
 	}
 }
+
+// TPMHandleSigner implements the crypto.Signer interface for an already-loaded TPMKey
+type TPMHandleSigner struct {
+	tpm     transport.TPMCloser
+	pubKey  crypto.PublicKey
+	keyAlgo tpm2.TPMAlgID
+	keySize int
+	handle  handle
+}
+
+func (t *TPMHandleSigner) Public() crypto.PublicKey {
+	return t.pubKey
+}
+
+func (t *TPMHandleSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	var digestalg, signalg tpm2.TPMAlgID
+	var digestlength int
+
+	switch opts.HashFunc() {
+	case crypto.SHA256:
+		digestalg = tpm2.TPMAlgSHA256
+		digestlength = 32
+	case crypto.SHA384:
+		digestalg = tpm2.TPMAlgSHA384
+		digestlength = 48
+	case crypto.SHA512:
+		digestalg = tpm2.TPMAlgSHA512
+		digestlength = 64
+	default:
+		return nil, fmt.Errorf("%s is not a supported hashing algorithm", opts.HashFunc())
+	}
+
+	if len(digest) != digestlength {
+		return nil, fmt.Errorf("incorrect checksum length. expected %v got %v", digestlength, len(digest))
+	}
+
+	signalg = t.keyAlgo
+	if _, ok := opts.(*rsa.PSSOptions); ok {
+		if signalg != tpm2.TPMAlgRSA {
+			return nil, fmt.Errorf("Attempting to use PSSOptions with non-RSA (alg %x) key", signalg)
+		}
+		signalg = tpm2.TPMAlgRSAPSS
+	}
+
+	rsp, err := TPMSign(t.tpm, t.handle, digest, digestalg, t.keySize, signalg)
+	if err != nil {
+		return nil, err
+	}
+	return EncodeSignatureASN1(rsp)
+}
+
+func NewTPMHandleSigner(
+	tpm transport.TPMCloser,
+	pubKey crypto.PublicKey,
+	keyAlgo tpm2.TPMAlgID,
+	keySize int,
+	handle handle,
+) TPMHandleSigner {
+	return TPMHandleSigner{tpm, pubKey, keyAlgo, keySize, handle}
+}
+
+func NewTPMHandleSignerFromKey(
+	tpm transport.TPMCloser,
+	key *TPMKey,
+	handle handle,
+) TPMHandleSigner {
+	pk, err := key.PublicKey()
+	// This shouldn't happen!
+	if err != nil {
+		panic(fmt.Errorf("failed producing public: %v", err))
+	}
+
+	return TPMHandleSigner{tpm, pk, key.KeyAlgo(), key.KeySize(), handle}
+}

--- a/tpm.go
+++ b/tpm.go
@@ -378,6 +378,8 @@ func TPMSign(tpm transport.TPMCloser, handle handle, digest []byte, digestalgo t
 		sigscheme = newRSASSASigScheme(digestalgo)
 	case tpm2.TPMAlgRSAPSS:
 		sigscheme = newRSAPSSSigScheme(digestalgo)
+	default:
+		return nil, fmt.Errorf("Unexpected key algorithm 0x%x", keyalgo)
 	}
 
 	// If we encounter RSA with SHA512 keys we use TPM_Decrypt to sign

--- a/tpm.go
+++ b/tpm.go
@@ -446,6 +446,10 @@ func SignASN1(sess *TPMSession, key *TPMKey, ownerauth, auth, digest []byte, dig
 	if err != nil {
 		return nil, err
 	}
+	return EncodeSignatureASN1(rsp)
+}
+
+func EncodeSignatureASN1(rsp *tpm2.TPMTSignature) ([]byte, error) {
 	switch rsp.SigAlg {
 	case tpm2.TPMAlgECDSA:
 		eccsig, err := rsp.Signature.ECDSA()

--- a/tpm.go
+++ b/tpm.go
@@ -316,7 +316,7 @@ func newRSAPSSSigScheme(digest tpm2.TPMAlgID) tpm2.TPMTSigScheme {
 	}
 }
 
-func Sign(sess *TPMSession, key *TPMKey, ownerauth, auth, digest []byte, digestalgo tpm2.TPMAlgID) (*tpm2.TPMTSignature, error) {
+func Sign(sess *TPMSession, key *TPMKey, ownerauth, auth, digest []byte, digestalgo, signalgo tpm2.TPMAlgID) (*tpm2.TPMTSignature, error) {
 	var digestlength int
 	var err error
 
@@ -364,7 +364,7 @@ func Sign(sess *TPMSession, key *TPMKey, ownerauth, auth, digest []byte, digesta
 		handle.Auth = tpm2.PasswordAuth(auth)
 	}
 
-	return TPMSign(sess.GetTPM(), *handle, digest, digestalgo, key.KeySize(), key.KeyAlgo(), sess.GetHMACIn())
+	return TPMSign(sess.GetTPM(), *handle, digest, digestalgo, key.KeySize(), signalgo, sess.GetHMACIn())
 }
 
 func TPMSign(tpm transport.TPMCloser, handle handle, digest []byte, digestalgo tpm2.TPMAlgID, keysize int, keyalgo tpm2.TPMAlgID, sess ...tpm2.Session) (*tpm2.TPMTSignature, error) {
@@ -441,8 +441,8 @@ func TPMSign(tpm transport.TPMCloser, handle handle, digest []byte, digestalgo t
 	}
 }
 
-func SignASN1(sess *TPMSession, key *TPMKey, ownerauth, auth, digest []byte, digestalgo tpm2.TPMAlgID) ([]byte, error) {
-	rsp, err := Sign(sess, key, ownerauth, auth, digest, digestalgo)
+func SignASN1(sess *TPMSession, key *TPMKey, ownerauth, auth, digest []byte, digestalgo, signalgo tpm2.TPMAlgID) ([]byte, error) {
+	rsp, err := Sign(sess, key, ownerauth, auth, digest, digestalgo, signalgo)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Includes #8 

- Adds a "raw" signer `TPMHandleSigner` that does not even actually require using keyfiles and definitely does not reload the key on every request
- Makes both signers support RSA-PSS, which unfortunately requires passing one more argument all the way through to `TPMSign`, breaking public API
- Makes both signers thread-safe via mutex